### PR TITLE
Remove linux.do link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,3 @@ The most important part of each environment is its `URL Rules`, because those ru
 - `make crx KEY=path/to/key.pem`: reuse an existing signing key
 
 If `KEY` is not provided, Chrome creates a new private key in `.keys/`, which changes the extension identity. Do not commit files in `.keys/`.
-
-## Friendly Links
-
-- [linux.do](https://linux.do/) - Where possible begins


### PR DESCRIPTION
## What changed

Removed the `linux.do` entry from the README and removed the now-empty Friendly Links section.

## Why

The link is no longer intended to be listed in the project README.

## Impact

Documentation-only change; no runtime behavior is affected.

## Validation

- `git diff --check`
- Confirmed only `README.md` is included in the commit
